### PR TITLE
handle errors in tear down code

### DIFF
--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -108,7 +108,16 @@ about_TestDrive
     }
     finally
     {
-        Invoke-TestGroupTeardownBlocks -Scope $pester.Scope
+        try
+        {
+            Invoke-TestGroupTeardownBlocks -Scope $pester.Scope
+        }
+        catch
+        {
+            $firstStackTraceLine = $_.InvocationInfo.PositionMessage.Trim() -split '\r?\n' | & $SafeCommands['Select-Object'] -First 1
+            $Pester.AddTestResult("Error occurred at $firstStackTraceLine", "Failed", $null, $_.Exception.Message, $firstStackTraceLine, $null, $null, $_)
+            $Pester.TestResult[-1] | Write-PesterResult
+        }
         if ($testDriveAdded) { Remove-TestDrive }
     }
 


### PR DESCRIPTION
If the AfterAll or AfterEach blocks throw, an error will be reported
