### PR TITLE
Remove reference to undefined $SafeCommands[] from Describe finally block

### DIFF
--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -114,7 +114,7 @@ about_TestDrive
         }
         catch
         {
-            $firstStackTraceLine = $_.InvocationInfo.PositionMessage.Trim() -split '\r?\n' | & $SafeCommands['Select-Object'] -First 1
+            $firstStackTraceLine = $_.InvocationInfo.PositionMessage.Trim() -split '\r?\n' | Select-Object -First 1
             $Pester.AddTestResult("Error occurred at $firstStackTraceLine", "Failed", $null, $_.Exception.Message, $firstStackTraceLine, $null, $null, $_)
             $Pester.TestResult[-1] | Write-PesterResult
         }


### PR DESCRIPTION
Fix https://github.com/PowerShell/psl-pester/issues/11

References to SafeCommands in Describe are not valid.  In the problem case, an exception thrown from Invoke-TestGroupTeardownBlocks (AfterAll, and AfterEach) will be caught but the reference to SafeCommands causes another unhandled exception bypassing $Pester.LeaveDescribe()

The symptom is cascading failures indicating nested Describe blocks are not allowed.